### PR TITLE
Use define-abbrev-table instead of defvar.

### DIFF
--- a/lisp/abbrevs.el
+++ b/lisp/abbrevs.el
@@ -1,6 +1,6 @@
 ;;-*-coding: utf-8; lexical-binding: t;-*-
 
-(defvar latex-mode-abbrev-table)
+(define-abbrev-table 'latex-mode-abbrev-table ())
 (require 'dynexp)
 
 ;; adapted from FasTeX (http://www.cds.caltech.edu/~fastex/fastex.html)


### PR DESCRIPTION
Fix error `Symbol's value as variable is void: latex-mode-abbrev-table`.